### PR TITLE
Fix weirdly-broken missing cache directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,8 +25,8 @@ else
 fi
 
 if ! [ -f "$CACHE_DIR/ejson" ]; then
-  heading "Installing ejson from GitHub release"
-  wget -q https://github.com/Shopify/ejson/releases/download/1.0.1/ejson_${PLATFORM}_binary -O "$CACHE_DIR/ejson"
+  heading "Installing ejson from GitHub release (Platform $PLATFORM)"
+  run_command_indented wget https://github.com/Shopify/ejson/releases/download/1.0.1/ejson_${PLATFORM}_binary -O "$CACHE_DIR/ejson"
   chmod +x "$CACHE_DIR/ejson"
 else
   heading "ejson is already installed"

--- a/bin/compile
+++ b/bin/compile
@@ -26,6 +26,7 @@ fi
 
 if ! [ -f "$CACHE_DIR/ejson" ]; then
   heading "Installing ejson from GitHub release (Platform $PLATFORM)"
+  mkdir -p "$CACHE_DIR"
   run_command_indented wget https://github.com/Shopify/ejson/releases/download/1.0.1/ejson_${PLATFORM}_binary -O "$CACHE_DIR/ejson"
   chmod +x "$CACHE_DIR/ejson"
 else


### PR DESCRIPTION
@sgnr reported a very strange bug: `/app/tmp/cache/ejson: No such file or directory` on deploy. AFAICT the cache dir doesn't actually exist on first deploy, so `mkdir -p` is necessary. If this is in the docs it must be hiding somewhere 😁

I made the installation a little more verbose as well.
